### PR TITLE
Add z-index to prevent :after from overlapping month name

### DIFF
--- a/datedropper.css
+++ b/datedropper.css
@@ -77,6 +77,7 @@
 	width:100px; 
 	overflow:hidden;
 	position:relative;
+	z-index:1;
 }
 .dd_ .dd_sw_ .dd_sl_ {
 	overflow-x:scroll;


### PR DESCRIPTION
Before:
![http://puu.sh/g21OZ/7d3999f6aa.png](http://puu.sh/g21OZ/7d3999f6aa.png)

After:
![http://puu.sh/g21PT/556f384597.png](http://puu.sh/g21PT/556f384597.png)